### PR TITLE
Move hardware requirments to make install page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ For documentation on using the tool, please see [How Tos](https://amdirt.readthe
 
 ## Install
 
+AMDirT has been tested on different Unix systems (macOS and Ubuntu) using Intel and AMD chips. If you suspect that AMDirT isn't working properly because you use a different hardware/OS, please open an [issue on GitHub](https://github.com/SPAAM-community/AMDirT/issues).
+
 ### 1. With [pip](https://pip.pypa.io/en/stable/getting-started/)
 
 ```bash

--- a/docs/source/how_to/miscellaneous.md
+++ b/docs/source/how_to/miscellaneous.md
@@ -71,7 +71,3 @@ The output from `AMDirT viewer`/`convert` will contain a list of accessions in a
 nextflow pull nf-core/fetchngs
 nextflow run nf-core/fetchngs --input AncientMetagenomeDir_nf_core_fetchngs_input_table.tsv`
 ```
-
-#### Supported hardware/OS
-
-AMDirT has been tested on different Unix systems (macOS and Ubuntu) using Intel and AMD chips. If you suspect that AMDirT isn't working properly because you use a different hardware/OS, please open an [issue on GitHub](https://github.com/SPAAM-community/AMDirT/issues).


### PR DESCRIPTION
The hardware section being buried in the `miscellanious` section of the command how-tos seemed to strange to me. 

This moves it to the 'install' page/README  which is where a user is more likely to 'care' about this information (they want to make sure it will run on their system before bothering to try installing it)