### PR TITLE
Fix tag parsing when version is  latest

### DIFF
--- a/AMDirT/core/__init__.py
+++ b/AMDirT/core/__init__.py
@@ -66,9 +66,9 @@ def get_amdir_tags():
             if tag['name'] != 'latest'
         ]
         return [
-            tag["name"]
+            tag
             for tag in tags
-            if version.parse(tag["name"]) >= version.parse("v22.09")
+            if version.parse(tag) >= version.parse("v22.09")
         ]
     else:
         logger.warning(

--- a/AMDirT/core/__init__.py
+++ b/AMDirT/core/__init__.py
@@ -60,9 +60,14 @@ def get_amdir_tags():
         "https://api.github.com/repos/SPAAM-community/AncientMetagenomeDir/tags"
     )
     if r.status_code == 200:
+        tags = [
+            tag['name']
+            for tag in r.json()
+            if tag['name'] != 'latest'
+        ]
         return [
             tag["name"]
-            for tag in r.json()
+            for tag in tags
             if version.parse(tag["name"]) >= version.parse("v22.09")
         ]
     else:


### PR DESCRIPTION
To fix `packaging.version.InvalidVersion: Invalid version: 'latest'` error reported in https://github.com/SPAAM-community/AncientMetagenomeDir/pull/1182 