### PR TITLE
Enable the access to the dates table

### DIFF
--- a/amdirt/assets/tables.json
+++ b/amdirt/assets/tables.json
@@ -22,5 +22,11 @@
     "ancientmetagenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientmetagenome-hostassociated/libraries/ancientmetagenome-hostassociated_libraries_schema.json",
     "ancientsinglegenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientsinglegenome-hostassociated/libraries/ancientsinglegenome-hostassociated_libraries_schema.json",
     "test": "https://raw.githubusercontent.com/SPAAM-community/amdirt/dev/tests/data/libraries_schema.json"
+  },
+  "dates": {
+    "ancientsinglegenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientsinglegenome-hostassociated/dates/ancientsinglegenome-hostassociated_dates.tsv"
+  },
+  "dates_schema": {
+    "ancientsinglegenome-hostassociated": "https://raw.githubusercontent.com/SPAAM-community/AncientMetagenomeDir/master/ancientsinglegenome-hostassociated/dates/ancientsinglegenome-hostassociated_dates_schema.json"
   }
 }

--- a/amdirt/cli.py
+++ b/amdirt/cli.py
@@ -320,7 +320,7 @@ def merge(ctx, no_args_is_help=True, **kwargs):
     "-y",
     "--table_type",
     help="Type of table to download",
-    type=click.Choice(["samples", "libraries"]),
+    type=click.Choice(["samples", "libraries", "dates"]),
     default="samples",
     show_default=True,
 )

--- a/amdirt/cli.py
+++ b/amdirt/cli.py
@@ -170,6 +170,11 @@ def viewer(ctx, no_args_is_help=True, **kwargs):
     help="Generate BibTeX file of all publications in input table",
 )
 @click.option(
+    "--dates",
+    is_flag=True,
+    help="Generate AncientMetagenomeDir dates table of all samples in input table"
+)
+@click.option(
     "--curl",
     is_flag=True,
     help="Generate bash script with curl-based download commands for all libraries of samples in input table",

--- a/amdirt/convert/__init__.py
+++ b/amdirt/convert/__init__.py
@@ -8,6 +8,7 @@ from amdirt.core import (
     prepare_aMeta_table,
     is_merge_size_zero,
     prepare_taxprofiler_table,
+    get_dates,
     get_libraries,
     get_remote_resources,
     get_json_path,
@@ -27,6 +28,7 @@ def run_convert(
     tables=None,
     output=".",
     bibliography=False,
+    dates=False,
     librarymetadata=False,
     curl=False,
     aspera=False,
@@ -137,6 +139,22 @@ def run_convert(
         col_drop = ["archive_accession"]
     else:
         col_drop = ["archive_accession", "sample_host"]
+
+    if dates == True:
+        if table_name not in remote_resources["dates"]:
+            logger.error(f"No dates for {table_name} available in AncientMetagenomeDir at the moment.")
+        else:
+            tbl_file = f"{output}/AncientMetagenomeDir_filtered_dates.tsv"
+            dates_tbl = pd.read_csv(remote_resources['dates'][table_name],
+                                    sep="\t")
+            logger.info(f"Writing filtered dates table to {tbl_file}")
+            datesmetadata = get_dates(table_name, samples, dates_tbl)
+            datesmetadata.to_csv(
+                tbl_file,
+                sep="\t",
+                index=False,
+            )
+
 
     if librarymetadata == True:
         tbl_file = f"{output}/AncientMetagenomeDir_filtered_libraries.tsv"

--- a/amdirt/core/__init__.py
+++ b/amdirt/core/__init__.py
@@ -141,6 +141,40 @@ def doi2bib(doi: str) -> str:
     return r.text
 
 
+def get_dates(
+    table_name: str,
+    samples: pd.DataFrame,
+    dates: pd.DataFrame
+):
+    """Get dates from the samples table
+
+    Args:
+        table_name (str): Name of the table of the table to convert
+        samples (pd.DataFrame): Sample table
+
+    Returns:
+        pd.DataFrame: filtered dates table
+    """
+    samples = (samples
+        .rename({'archive_accession': 'archive_sample_accession'}, axis=1)
+    )
+    if table_name in [
+        "ancientmetagenome-environmental",
+    ]:
+        sel_col = ["archive_accession"]
+    else:
+        sel_col = ["project_name", "publication_year",
+                   "sample_name", "singlegenome_species",
+                   "archive_project", "archive_sample_accession"]
+    selected_dates = dates.merge(
+        samples.loc[:, sel_col],
+        on=sel_col,
+        how="inner"
+    )
+
+    return selected_dates
+
+
 @st.cache_data
 def get_libraries(
     table_name: str,

--- a/amdirt/download/__init__.py
+++ b/amdirt/download/__init__.py
@@ -55,8 +55,13 @@ def download(table: str, table_type: str, release: str, output: str = ".") -> st
     logger.info(
         f"Downloading {table} {table_type} table from {release} release, saving to {output}/{table_filename}"
     )
-    t = requests.get(resources[table_type][table].replace("master", release))
-    with open(table_filename, "w") as fh:
-        fh.write(t.text)
+    try:
+        t = requests.get(resources[table_type][table].replace("master", release))
+        with open(f"{output}/{table_filename}", "w") as fh:
+            fh.write(t.text)
+    except KeyError:
+        logger.warning(
+            f"Invalid table: {table}. {table} currently does not have any {table_type} information."
+        )
 
     return table_filename

--- a/amdirt/download/__init__.py
+++ b/amdirt/download/__init__.py
@@ -16,7 +16,7 @@ def download(table: str, table_type: str, release: str, output: str = ".") -> st
     table : str
         The AncientMetagenomeDir table to download.
     table_type : str
-        The type of table to download. Allowed values are ['samples', 'libraries'].
+        The type of table to download. Allowed values are ['samples', 'libraries', 'dates'].
     release : str
         The release of the table to download. Must be a valid release tag.
     output: str
@@ -47,9 +47,9 @@ def download(table: str, table_type: str, release: str, output: str = ".") -> st
     if check_allowed_values(tables, table) is False:
         raise ValueError(f"Invalid table: {table}. Allowed values are {tables}")
 
-    if check_allowed_values(["samples", "libraries"], table_type) is False:
+    if check_allowed_values(["samples", "libraries", "dates"], table_type) is False:
         raise ValueError(
-            f"Invalid table type: {table_type}. Allowed values are ['samples', 'libraries']"
+            f"Invalid table type: {table_type}. Allowed values are ['samples', 'libraries', 'dates']"
         )
     table_filename = f"{table}_{table_type}_{release}.tsv"
     logger.info(


### PR DESCRIPTION
This PR enables

- the download of the complete dates table using `amdirt download`
- the filtering of the dates table for a subset of samples using `amdirt convert`

Additionally, it fixes the #175 issue by including the output folder in the filename.